### PR TITLE
[#15] Test scaffolds not generated

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,8 @@
-lib
-coverage
-test
-.eslintignore
-.eslintrc
-.gitignore
+/lib
+/coverage
+/test
+.eslint*
 .jshint*
+.gitignore
 .npmignore
 circle.yml


### PR DESCRIPTION
When I put `test` in `.npmignore`, it worked for both `./test` and `./template/test`, so when package was published, `template/test` folder was omitted.
