### PR TITLE
Fix main JS entry point path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cf-package",
   "version": "0.1.0",
   "description": "Cloverfield Package Scaffold",
-  "main": "index.js",
+  "main": "build/cli.js",
   "bin": {
     "cf-package": "build/cli.js"
   },


### PR DESCRIPTION
This is required if we want to have automatic programmatic access from `cloverfield`.
The fix is needed anyway, but:

if we are using global modules, then I cannot just require `/Users/nkbt/.nvm/v0.10.40/node_modules/cf-package`, I need an actual file, so we need to parse `package.json` to find out which file to require.
