### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,17 +39,17 @@
   "dependencies": {
     "babel": "^5.8.23",
     "glob": "^5.0.14",
-    "handlebars": "^3.0.3",
+    "handlebars": "^4.0.0",
     "mkdirp": "^0.5.1",
     "nomnom": "^1.8.1",
     "prompt": "^0.2.14"
   },
   "devDependencies": {
-    "babel-eslint": "^4.1.0",
+    "babel-eslint": "^4.1.1",
     "blue-tape": "^0.1.10",
-    "eslint": "^1.3.0",
+    "eslint": "^1.3.1",
     "faucet": "0.0.1",
-    "isparta": "^3.0.3",
+    "isparta": "^3.0.4",
     "nsp": "^1.1.0",
     "precommit-hook": "^3.0.0",
     "rimraf": "^2.4.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/cloverfield-tools/cf-package",
   "dependencies": {
-    "babel": "^5.8.21",
+    "babel": "^5.8.23",
     "glob": "^5.0.14",
     "handlebars": "^3.0.3",
     "mkdirp": "^0.5.1",
@@ -45,15 +45,15 @@
     "prompt": "^0.2.14"
   },
   "devDependencies": {
-    "babel-eslint": "^4.0.5",
+    "babel-eslint": "^4.1.0",
     "blue-tape": "^0.1.10",
-    "eslint": "^1.1.0",
+    "eslint": "^1.3.0",
     "faucet": "0.0.1",
     "isparta": "^3.0.3",
-    "nsp": "^1.0.3",
+    "nsp": "^1.1.0",
     "precommit-hook": "^3.0.0",
-    "rimraf": "^2.4.2",
-    "sinon": "^1.15.4",
+    "rimraf": "^2.4.3",
+    "sinon": "^1.16.1",
     "tap-xunit": "^1.1.1"
   },
   "pre-commit": [


### PR DESCRIPTION
That did not fix the build, since `handlebars` dependencies are not updated (but still good to have)
