### PR TITLE
 [#26] Missing .eslintrc

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,8 @@
 /lib
 /coverage
 /test
-.eslint*
-.jshint*
-.gitignore
-.npmignore
-circle.yml
+/.eslint*
+/.jshint*
+/.gitignore
+/.npmignore
+/circle.yml


### PR DESCRIPTION
Well, I know that was something ridiculously stupid like that... Apparently I "fixed" `.npmignore` for tests, but not for the rest of ignored files.

In this way it is fixed and all files are included in the output

I added some logging to check if all is good and here is output (we actually need #9 done so it stops being black box)

``` sh
C:\www\t
λ node_modules\.bin\cf-package
======= SOURCES =======
[ 'C:\\www\\t\\node_modules\\cf-package\\template\\.babelrc',
  'C:\\www\\t\\node_modules\\cf-package\\template\\.editorconfig',
  'C:\\www\\t\\node_modules\\cf-package\\template\\.eslintrc',
  'C:\\www\\t\\node_modules\\cf-package\\template\\.npmignore',
  'C:\\www\\t\\node_modules\\cf-package\\template\\.travis.yml',
  'C:\\www\\t\\node_modules\\cf-package\\template\\CONTRIBUTING.md',
  'C:\\www\\t\\node_modules\\cf-package\\template\\LICENSE',
  'C:\\www\\t\\node_modules\\cf-package\\template\\README.md',
  'C:\\www\\t\\node_modules\\cf-package\\template\\circle.yml',
  'C:\\www\\t\\node_modules\\cf-package\\template\\docs\\contributing\\index.md',
  'C:\\www\\t\\node_modules\\cf-package\\template\\docs\\contributing\\versions\\index.md',
  'C:\\www\\t\\node_modules\\cf-package\\template\\package.json',
  'C:\\www\\t\\node_modules\\cf-package\\template\\scripts\\buildProduction.js',
  'C:\\www\\t\\node_modules\\cf-package\\template\\scripts\\buildWebpack.js',
  'C:\\www\\t\\node_modules\\cf-package\\template\\source\\index.js',
  'C:\\www\\t\\node_modules\\cf-package\\template\\test\\index.js',
  'C:\\www\\t\\node_modules\\cf-package\\template\\webpack.config.js' ]
======= DESTINATIONS =======
[ 'C:\\www\\t\\.babelrc',
  'C:\\www\\t\\.editorconfig',
  'C:\\www\\t\\.eslintrc',
  'C:\\www\\t\\.npmignore',
  'C:\\www\\t\\.travis.yml',
  'C:\\www\\t\\CONTRIBUTING.md',
  'C:\\www\\t\\LICENSE',
  'C:\\www\\t\\README.md',
  'C:\\www\\t\\circle.yml',
  'C:\\www\\t\\docs\\contributing\\index.md',
  'C:\\www\\t\\docs\\contributing\\versions\\index.md',
  'C:\\www\\t\\package.json',
  'C:\\www\\t\\scripts\\buildProduction.js',
  'C:\\www\\t\\scripts\\buildWebpack.js',
  'C:\\www\\t\\source\\index.js',
  'C:\\www\\t\\test\\index.js',
  'C:\\www\\t\\webpack.config.js' ]
```

PS: yes, fixing it on Windows... I decided to do development on Windows at home for better code/tools discipline ;)
