### PR TITLE
[#36] Replace precommit-hook with husky for git hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,3 @@ build
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
 
-.jshint*

--- a/.npmignore
+++ b/.npmignore
@@ -2,7 +2,6 @@
 /coverage
 /test
 /.eslint*
-/.jshint*
 /.gitignore
 /.npmignore
 /circle.yml

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "check": "npm run lint && npm test && npm run audit && npm outdated --depth 0",
     "prebuild": "rimraf build",
     "build": "babel lib --out-dir build",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "precommit": "npm run lint",
+    "prepush": "npm run validate"
   },
   "repository": {
     "type": "git",
@@ -49,14 +51,11 @@
     "blue-tape": "^0.1.10",
     "eslint": "^1.3.1",
     "faucet": "0.0.1",
+    "husky": "^0.10.1",
     "isparta": "^3.0.4",
     "nsp": "^1.1.0",
-    "precommit-hook": "^3.0.0",
     "rimraf": "^2.4.3",
     "sinon": "^1.16.1",
     "tap-xunit": "^1.1.1"
-  },
-  "pre-commit": [
-    "lint"
-  ]
+  }
 }

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -27,6 +27,3 @@ build/Release
 node_modules
 
 build
-.validate.json
-.jshintrc
-.jshintignore

--- a/template/package.json
+++ b/template/package.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "main": "build/index.js",
   "scripts": {
-    "init": "rimraf .validate.json && rimraf .jshintrc",
     "clean": "rimraf build",
     "lint": "eslint source test",
     "prebuild": "npm run clean",
@@ -25,11 +24,10 @@
     "deps:missing": "dependency-check package.json",
     "deps:extra": "dependency-check package.json --extra --no-dev --ignore",
     "precheck": "npm run validate",
-    "check": "npm run audit && npm run deps && npm outdated --depth 0"
+    "check": "npm run audit && npm run deps && npm outdated --depth 0",
+    "precommit": "npm run lint",
+    "prepush": "npm run validate"
   },
-  "pre-commit": [
-    "lint"
-  ],
   "devDependencies": {
     "babel": "^5.8.21",
     "babel-eslint": "^4.0.5",
@@ -42,10 +40,10 @@
     "eslint-loader": "^1.0.0",
     "eslint-plugin-react": "^2.3.0",
     "faucet": "0.0.1",
+    "husky": "^0.10.1",
     "isparta": "^3.0.3",
     "node-libs-browser": "^0.5.2",
     "nsp": "^1.0.3",
-    "precommit-hook": "^3.0.0",
     "rimraf": "^2.4.2",
     "webpack": "^1.11.0"
   },


### PR DESCRIPTION
@nkbt 

One thing i've noticed is that husky creates hooks with predefined names which match to npm scripts, i don't know if you are ok with this convention.

Also i don't know if the template it uses for hook generation is bulletproof regarding the PATH for future node version updates (ie: using nvm), check any hook it creates to see what i mean
