### PR TITLE
Merge pre-existing package.json with file generated by Cloverfield

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015"]
+  "presets": ["es2015"],
+  "plugins": ["transform-object-rest-spread"]
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -4,6 +4,8 @@
 import 'babel-polyfill';
 import prompt from 'prompt';
 import {parse} from 'nomnom';
+import parseAuthor from 'parse-author';
+import parseGithub from 'parse-github-url';
 import glob from 'glob';
 import parseProps from './parseProps';
 import generate from './generate';
@@ -20,29 +22,25 @@ import {
 
 let schema = {properties};
 
-let gitHub, author;
+let gitHub, authorInfo;
 const existingPackage = getPackage();
 if (existingPackage) {
   console.log(`Existing package.json file has been used to get default variables.`);
-  // console.log('name is ', existingPackage.name);
   schema.properties = {...schema.properties, ...packageProperties};
   schema.properties['package.name'].default = existingPackage.name;
   schema.properties['package.description'].default = existingPackage.description;
-  if (existingPackage.repository) {
-    gitHub = existingPackage.repository.url.match(/github.com:(.*)\//);
-    if (gitHub) {
-      schema.properties['user.github'].default = gitHub[1];
-    }
+  if (existingPackage.repository && existingPackage.repository.url) {
+    gitHub = parseGithub(existingPackage.repository.url).owner;
+    schema.properties['user.github'].default = gitHub;
   }
   if (existingPackage.author) {
-    schema.properties['user.name'].default = existingPackage.author;
-    // author = existingPackage.author.match(/(.*)((?:\s<)([\w\d@\.]*)(?:>)){0,1}/);
-    // if (author) {
-    //   schema.properties['user.name'].default = author[1];
-    //   if (author.length == 3) {
-    //     schema.properties['user.email'].default = author[2];
-    //   }
-    // }
+    authorInfo = parseAuthor(existingPackage.author);
+    if (authorInfo.name) {
+      schema.properties['user.name'].default = authorInfo.name;
+    }
+    if (authorInfo.email) {
+      schema.properties['user.email'].default = authorInfo.email;
+    }
   }
   console.dir(schema);
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -7,6 +7,7 @@ import {parse} from 'nomnom';
 import glob from 'glob';
 import parseProps from './parseProps';
 import generate from './generate';
+import {getPackage, mergePackages} from './mergePack';
 import fs from 'fs';
 import mkdirp from 'mkdirp';
 import path from 'path';
@@ -58,6 +59,7 @@ const scaffold = args => {
   getPrompt()
     .then(parseProps(defaults))
     .then(generate(srcContent))
+    .then(mergePackages(getPackage(), destinations))
     .then(saveCompiled)
     .then(() => {
       console.log(green('OK'), 'Generation completed', '\n');

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -11,14 +11,41 @@ import {getPackage, mergePackages} from './mergePack';
 import fs from 'fs';
 import mkdirp from 'mkdirp';
 import path from 'path';
-import {properties, defaults} from './properties';
+import {packageProperties, properties, defaults} from './properties';
 import {
   blackBright as grey,
   greenBright as green,
   yellowBright as yellow,
   redBright as red} from 'cli-color';
 
-const schema = {properties};
+let schema = {properties};
+
+let gitHub, author;
+const existingPackage = getPackage();
+if (existingPackage) {
+  console.log(`Existing package.json file has been used to get default variables.`);
+  // console.log('name is ', existingPackage.name);
+  schema.properties = {...schema.properties, ...packageProperties};
+  schema.properties['package.name'].default = existingPackage.name;
+  schema.properties['package.description'].default = existingPackage.description;
+  if (existingPackage.repository) {
+    gitHub = existingPackage.repository.url.match(/github.com:(.*)\//);
+    if (gitHub) {
+      schema.properties['user.github'].default = gitHub[1];
+    }
+  }
+  if (existingPackage.author) {
+    schema.properties['user.name'].default = existingPackage.author;
+    // author = existingPackage.author.match(/(.*)((?:\s<)([\w\d@\.]*)(?:>)){0,1}/);
+    // if (author) {
+    //   schema.properties['user.name'].default = author[1];
+    //   if (author.length == 3) {
+    //     schema.properties['user.email'].default = author[2];
+    //   }
+    // }
+  }
+  console.dir(schema);
+}
 
 
 Object.assign(prompt, {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -9,6 +9,7 @@ import parseGithub from 'parse-github-url';
 import glob from 'glob';
 import parseProps from './parseProps';
 import generate from './generate';
+import packageExtras from './packageExtras';
 import {getPackage, mergePackages} from './mergePack';
 import fs from 'fs';
 import mkdirp from 'mkdirp';
@@ -82,6 +83,7 @@ const scaffold = args => {
   prompt.override = args;
 
   getPrompt()
+    .then(packageExtras(existingPackage))
     .then(parseProps(defaults))
     .then(generate(srcContent))
     .then(mergePackages(getPackage(), destinations))

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -4,13 +4,11 @@
 import 'babel-polyfill';
 import prompt from 'prompt';
 import {parse} from 'nomnom';
-import parseAuthor from 'parse-author';
-import parseGithub from 'parse-github-url';
 import glob from 'glob';
 import parseProps from './parseProps';
 import generate from './generate';
-import packageExtras from './packageExtras';
-import {getPackage, mergePackages} from './mergePack';
+import setPackageProps from './packageExtras';
+import {getPackage, getPackageProps, mergePackages} from './mergePack';
 import fs from 'fs';
 import mkdirp from 'mkdirp';
 import path from 'path';
@@ -22,30 +20,8 @@ import {
   redBright as red} from 'cli-color';
 
 let schema = {properties};
-
-let gitHub, authorInfo;
 const existingPackage = getPackage();
-if (existingPackage) {
-  console.log(`Existing package.json file has been used to get default variables.`);
-  schema.properties = {...schema.properties, ...packageProperties};
-  schema.properties['package.name'].default = existingPackage.name;
-  schema.properties['package.description'].default = existingPackage.description;
-  if (existingPackage.repository && existingPackage.repository.url) {
-    gitHub = parseGithub(existingPackage.repository.url).owner;
-    schema.properties['user.github'].default = gitHub;
-  }
-  if (existingPackage.author) {
-    authorInfo = parseAuthor(existingPackage.author);
-    if (authorInfo.name) {
-      schema.properties['user.name'].default = authorInfo.name;
-    }
-    if (authorInfo.email) {
-      schema.properties['user.email'].default = authorInfo.email;
-    }
-  }
-  console.dir(schema);
-}
-
+schema = getPackageProps(existingPackage, packageProperties, schema);
 
 Object.assign(prompt, {
   message: '>'.green,
@@ -83,7 +59,7 @@ const scaffold = args => {
   prompt.override = args;
 
   getPrompt()
-    .then(packageExtras(existingPackage))
+    .then(setPackageProps(existingPackage))
     .then(parseProps(defaults))
     .then(generate(srcContent))
     .then(mergePackages(getPackage(), destinations))

--- a/lib/mergePack.js
+++ b/lib/mergePack.js
@@ -17,7 +17,7 @@ export const mergePackages = (origPackage, destinations) => compiledFiles => {
     const newPackagePath = path.join(process.cwd(), 'package.json');
     const packageIndex = destinations.indexOf(newPackagePath);
     const packageContents = JSON.parse(compiledFiles[packageIndex]);
-    const mergedPack = JSON.stringify(merge(origPackage, packageContents), null, 2);
+    const mergedPack = JSON.stringify(merge(packageContents, origPackage), null, 2);
     compiledFiles[packageIndex] = mergedPack;
   }
   return compiledFiles;

--- a/lib/mergePack.js
+++ b/lib/mergePack.js
@@ -2,7 +2,7 @@ import merge from 'package-merge';
 import fs from 'fs';
 import path from 'path';
 
-const getPackage = () => {
+export const getPackage = () => {
   let origPackage;
   try {
     origPackage = fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8');
@@ -12,7 +12,7 @@ const getPackage = () => {
   return origPackage;
 };
 
-const mergePackages = (origPackage, destinations) => compiledFiles => {
+export const mergePackages = (origPackage, destinations) => compiledFiles => {
   if (origPackage) {
     const newPackagePath = path.join(process.cwd(), 'package.json');
     const packageIndex = destinations.indexOf(newPackagePath);
@@ -22,4 +22,3 @@ const mergePackages = (origPackage, destinations) => compiledFiles => {
   }
   return compiledFiles;
 };
-export {getPackage, mergePackages};

--- a/lib/mergePack.js
+++ b/lib/mergePack.js
@@ -1,11 +1,11 @@
-import merge from 'package-merge';
+import merge from 'lodash.merge';
 import fs from 'fs';
 import path from 'path';
 
 export const getPackage = () => {
   let origPackage;
   try {
-    origPackage = fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8');
+    origPackage = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
   } catch (e) {
     origPackage = false;
   }
@@ -16,8 +16,8 @@ export const mergePackages = (origPackage, destinations) => compiledFiles => {
   if (origPackage) {
     const newPackagePath = path.join(process.cwd(), 'package.json');
     const packageIndex = destinations.indexOf(newPackagePath);
-    const packageContents = compiledFiles[packageIndex];
-    const mergedPack = merge(origPackage, packageContents);
+    const packageContents = JSON.parse(compiledFiles[packageIndex]);
+    const mergedPack = JSON.stringify(merge(origPackage, packageContents), null, 2);
     compiledFiles[packageIndex] = mergedPack;
   }
   return compiledFiles;

--- a/lib/mergePack.js
+++ b/lib/mergePack.js
@@ -1,0 +1,25 @@
+import merge from 'package-merge';
+import fs from 'fs';
+import path from 'path';
+
+const getPackage = () => {
+  let origPackage;
+  try {
+    origPackage = fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8');
+  } catch (e) {
+    origPackage = false;
+  }
+  return origPackage;
+};
+
+const mergePackages = (origPackage, destinations) => compiledFiles => {
+  if (origPackage) {
+    const newPackagePath = path.join(process.cwd(), 'package.json');
+    const packageIndex = destinations.indexOf(newPackagePath);
+    const packageContents = compiledFiles[packageIndex];
+    const mergedPack = merge(origPackage, packageContents);
+    compiledFiles[packageIndex] = mergedPack;
+  }
+  return compiledFiles;
+};
+export {getPackage, mergePackages};

--- a/lib/mergePack.js
+++ b/lib/mergePack.js
@@ -1,6 +1,8 @@
-import merge from 'lodash.merge';
 import fs from 'fs';
 import path from 'path';
+import merge from 'lodash.merge';
+import parseAuthor from 'parse-author';
+import parseGithub from 'parse-github-url';
 
 export const getPackage = () => {
   let origPackage;
@@ -10,6 +12,31 @@ export const getPackage = () => {
     origPackage = false;
   }
   return origPackage;
+};
+
+export const getPackageProps = (existingPackage, packageProperties, schema) => {
+  let gitHub, authorInfo;
+  if (existingPackage) {
+    console.log(`Existing package.json file has been used to get default variables.`);
+    schema.properties = {...schema.properties, ...packageProperties};
+    schema.properties['package.name'].default = existingPackage.name;
+    schema.properties['package.description'].default = existingPackage.description;
+    // Try to get Name, Email & GitHub Username
+    if (existingPackage.repository && existingPackage.repository.url) {
+      gitHub = parseGithub(existingPackage.repository.url).owner;
+      schema.properties['user.github'].default = gitHub;
+    }
+    if (existingPackage.author) {
+      authorInfo = parseAuthor(existingPackage.author);
+      if (authorInfo.name) {
+        schema.properties['user.name'].default = authorInfo.name;
+      }
+      if (authorInfo.email) {
+        schema.properties['user.email'].default = authorInfo.email;
+      }
+    }
+  }
+  return schema;
 };
 
 export const mergePackages = (origPackage, destinations) => compiledFiles => {

--- a/lib/packageExtras.js
+++ b/lib/packageExtras.js
@@ -1,26 +1,16 @@
-// import fs from 'fs';
-// import path from 'path';
-// const templatePackage = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'template', 'package.json'), 'utf-8'));
-// const templatePackage = JSON.parse(fs.readFileSync(path.join('..', '/template', 'package.json'), 'utf-8'));
-const templatePackage = require('../template/package.json');
+import templatePackage from '../template/package.json';
 
-const packageExtras = userPackage => props => {
-  if (props['package.dependencies']) {
-    props['package.dependencies'] = {...templatePackage.dependencies, ...userPackage.dependencies};
-  } else {
-    props['package.dependencies'] = {...templatePackage.dependencies};
-  }
-  if (props['package.devDependencies']) {
-    props['package.devDependencies'] = {...templatePackage.devDependencies, ...userPackage.devDependencies};
-  } else {
-    props['package.devDependencies'] = {...templatePackage.devDependencies};
-  }
-  if (props['package.scripts']) {
-    props['package.scripts'] = {...templatePackage.scripts, ...userPackage.scripts};
-  } else {
-    props['package.scripts'] = {...templatePackage.scripts};
-  }
+const packageFields = ['dependencies', 'devDependencies', 'scripts'];
+
+const setPackageProps = userPackage => props => {
+  packageFields.forEach((field) => {
+    if (props[`package.${field}`]) {
+      props[`package.${field}`] = {...templatePackage[field], ...userPackage[field]};
+    } else {
+      props[`package.${field}`] = {...templatePackage[field]};
+    }
+  });
   return props;
-}
+};
 
-export default packageExtras;
+export default setPackageProps;

--- a/lib/packageExtras.js
+++ b/lib/packageExtras.js
@@ -1,0 +1,26 @@
+// import fs from 'fs';
+// import path from 'path';
+// const templatePackage = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'template', 'package.json'), 'utf-8'));
+// const templatePackage = JSON.parse(fs.readFileSync(path.join('..', '/template', 'package.json'), 'utf-8'));
+const templatePackage = require('../template/package.json');
+
+const packageExtras = userPackage => props => {
+  if (props['package.dependencies']) {
+    props['package.dependencies'] = {...templatePackage.dependencies, ...userPackage.dependencies};
+  } else {
+    props['package.dependencies'] = {...templatePackage.dependencies};
+  }
+  if (props['package.devDependencies']) {
+    props['package.devDependencies'] = {...templatePackage.devDependencies, ...userPackage.devDependencies};
+  } else {
+    props['package.devDependencies'] = {...templatePackage.devDependencies};
+  }
+  if (props['package.scripts']) {
+    props['package.scripts'] = {...templatePackage.scripts, ...userPackage.scripts};
+  } else {
+    props['package.scripts'] = {...templatePackage.scripts};
+  }
+  return props;
+}
+
+export default packageExtras;

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -16,6 +16,27 @@ export const defaults = {
   }
 };
 
+export const packageProperties = {
+  'deps': {
+    description: 'Keep existing dependencies?: ',
+    message: 'Required',
+    type: 'boolean',
+    required: true
+  },
+  'devDeps': {
+    description: 'Keep existing devDependencies?: ',
+    message: 'Required',
+    type: 'boolean',
+    required: true
+  },
+  'scripts': {
+    description: 'Keep existing scripts?: ',
+    message: 'Required',
+    type: 'boolean',
+    required: true
+  }
+};
+
 
 export const properties = {
   'user.name': {

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -12,25 +12,28 @@ export const defaults = {
   },
   package: {
     name: '',
-    description: ''
+    description: '',
+    dependencies: {},
+    devDependencies: {},
+    scripts: {}
   }
 };
 
 export const packageProperties = {
-  'deps': {
-    description: 'Keep existing dependencies?: ',
+  'package.dependencies': {
+    description: 'Keep existing dependencies? (true|false): ',
     message: 'Required',
     type: 'boolean',
     required: true
   },
-  'devDeps': {
-    description: 'Keep existing devDependencies?: ',
+  'package.devDependencies': {
+    description: 'Keep existing devDependencies? (true|false): ',
     message: 'Required',
     type: 'boolean',
     required: true
   },
-  'scripts': {
-    description: 'Keep existing scripts?: ',
+  'package.scripts': {
+    description: 'Keep existing scripts? (true|false): ',
     message: 'Required',
     type: 'boolean',
     required: true

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "husky": "^0.10.1",
     "isparta": "^3.0.4",
     "nsp": "^2.0.2",
+    "package-merge": "^0.1.2",
+    "precommit-hook": "^3.0.0",
     "rimraf": "^2.4.3",
     "sinon": "^1.16.1",
     "tap-xunit": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^4.1.1",
+    "babel-plugin-transform-object-rest-spread": "^6.5.0",
     "blue-tape": "^0.1.10",
     "eslint": "^1.3.1",
     "faucet": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "husky": "^0.10.1",
     "isparta": "^3.0.4",
     "nsp": "^2.0.2",
+    "parse-author": "^0.2.0",
+    "parse-github-url": "^0.3.0",
     "rimraf": "^2.4.3",
     "sinon": "^1.16.1",
     "tap-xunit": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "cli-color": "^1.0.0",
     "glob": "^5.0.14",
     "handlebars": "^4.0.0",
+    "lodash.merge": "^3.3.2",
     "mkdirp": "^0.5.1",
     "nomnom": "^1.8.1",
     "prompt": "^0.2.14"
@@ -58,7 +59,6 @@
     "isparta": "^3.0.4",
     "nsp": "^2.0.2",
     "package-merge": "^0.1.2",
-    "precommit-hook": "^3.0.0",
     "rimraf": "^2.4.3",
     "sinon": "^1.16.1",
     "tap-xunit": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "husky": "^0.10.1",
     "isparta": "^3.0.4",
     "nsp": "^2.0.2",
-    "package-merge": "^0.1.2",
     "rimraf": "^2.4.3",
     "sinon": "^1.16.1",
     "tap-xunit": "^1.1.1"

--- a/template/package.json
+++ b/template/package.json
@@ -28,11 +28,11 @@
     "precommit": "npm run lint",
     "prepush": "npm run validate"
   },
-  "devDependencies": {
+  "devDependencies":  {
     "babel-cli": "^6.2.0",
     "babel-core": "^6.0.0",
     "babel-preset-es2015": "^6.1.18",
-    "babel-preset-stage-1":"^6.0.0",
+    "babel-preset-stage-1": "^6.0.0",
     "babel-eslint": "^4.0.5",
     "babel-loader": "^6.0.0",
     "babel-plugin-transform-object-assign": "^6.1.18",

--- a/test/lib/mergePack-test.js
+++ b/test/lib/mergePack-test.js
@@ -1,0 +1,38 @@
+import {test} from 'blue-tape';
+import {mergePackages} from '../../lib/mergePack';
+import path from 'path';
+
+test('Merge Packages', t => {
+
+  const packPath = path.join(process.cwd(), 'package.json');
+  const templatedFile = JSON.stringify({
+    name: 'templatePackage',
+    description: 'This should overwrite stuff'
+  });
+  const originalFile = JSON.stringify({
+    name: 'originalPackage',
+    description: 'This should be overwritten by a template',
+    scripts: {
+      start: 'do a lotta stuff'
+    }
+  });
+  const mergedFile = JSON.stringify({
+    name: 'templatePackage',
+    description: 'This should overwrite stuff',
+    scripts: {
+      start: 'do a lotta stuff'
+    }
+  });
+
+  t.ok(mergePackages instanceof Function, 'should be function');
+
+  t.ok(mergePackages() instanceof Function, 'should return function');
+
+  t.deepEqual(mergePackages(false, [packPath])([templatedFile]), [templatedFile],
+    'should return the generated package when there is no pre-existing package.json');
+
+  t.deepEqual(mergePackages(originalFile, [packPath])([templatedFile]), [mergedFile],
+    'should merge an existing package.json with template and return results');
+
+  t.end();
+});

--- a/test/lib/mergePack-test.js
+++ b/test/lib/mergePack-test.js
@@ -7,27 +7,27 @@ test('Merge Packages', t => {
   const packPath = path.join(process.cwd(), 'package.json');
   const templatedFile = JSON.stringify({
     name: 'templatePackage',
-    description: 'This should overwrite stuff',
+    description: 'This should not overwrite stuff',
     main: 'src/index.js',
     scripts: {
-      start: 'do a lotta stuff',
+      start: 'do a lotta new stuff',
       test: 'mocha this package'
     }
   });
   const originalFile = {
     name: 'originalPackage',
-    description: 'This should be overwritten by a template',
+    description: 'This should not be overwritten by a template',
     scripts: {
-      start: 'do a lotta stuff',
+      start: 'do a lotta old stuff',
       lint: 'lint this package'
     }
   };
   const mergedFile = {
-    name: 'templatePackage',
-    description: 'This should overwrite stuff',
+    name: 'originalPackage',
+    description: 'This should not be overwritten by a template',
     main: 'src/index.js',
     scripts: {
-      start: 'do a lotta stuff',
+      start: 'do a lotta old stuff',
       lint: 'lint this package',
       test: 'mocha this package'
     }

--- a/test/lib/mergePack-test.js
+++ b/test/lib/mergePack-test.js
@@ -45,5 +45,7 @@ test('Merge Packages', t => {
   t.deepEqual(JSON.parse(merger), mergedFile,
     'should merge an existing package.json with template and return results');
 
+  t.ok(merger.match(/\s\s/), 'merged package should be formatted with spaces');
+
   t.end();
 });

--- a/test/lib/mergePack-test.js
+++ b/test/lib/mergePack-test.js
@@ -7,22 +7,31 @@ test('Merge Packages', t => {
   const packPath = path.join(process.cwd(), 'package.json');
   const templatedFile = JSON.stringify({
     name: 'templatePackage',
-    description: 'This should overwrite stuff'
+    description: 'This should overwrite stuff',
+    main: 'src/index.js',
+    scripts: {
+      start: 'do a lotta stuff',
+      test: 'mocha this package'
+    }
   });
-  const originalFile = JSON.stringify({
+  const originalFile = {
     name: 'originalPackage',
     description: 'This should be overwritten by a template',
     scripts: {
-      start: 'do a lotta stuff'
+      start: 'do a lotta stuff',
+      lint: 'lint this package'
     }
-  });
-  const mergedFile = JSON.stringify({
+  };
+  const mergedFile = {
     name: 'templatePackage',
     description: 'This should overwrite stuff',
+    main: 'src/index.js',
     scripts: {
-      start: 'do a lotta stuff'
+      start: 'do a lotta stuff',
+      lint: 'lint this package',
+      test: 'mocha this package'
     }
-  });
+  };
 
   t.ok(mergePackages instanceof Function, 'should be function');
 
@@ -31,7 +40,9 @@ test('Merge Packages', t => {
   t.deepEqual(mergePackages(false, [packPath])([templatedFile]), [templatedFile],
     'should return the generated package when there is no pre-existing package.json');
 
-  t.deepEqual(mergePackages(originalFile, [packPath])([templatedFile]), [mergedFile],
+  const merger = mergePackages(originalFile, [packPath])([templatedFile])[0];
+
+  t.deepEqual(JSON.parse(merger), mergedFile,
     'should merge an existing package.json with template and return results');
 
   t.end();


### PR DESCRIPTION
Re issue #23 
- Tried to make it fit the pre-existing code structure as much as possible.
- There is some "intelligence" to the merging from the `package-merge` package rather than a straight object merge - keywords field will be merged without duplicates etc. Might want to take a quick look at that package to see if its desired behaviour: 
  - https://github.com/izaakschroeder/package-merge/blob/master/lib/merge.js
