### PR TITLE
[#45] Adds libraryTarget to webpack config for correct exports

### DIFF
--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -21,7 +21,8 @@ module.exports = {
 
   output: {
     filename: minify ? 'index.min.js' : 'index.js',
-    path: path.resolve('./build')
+    path: path.resolve('./build'),
+    libraryTarget: 'commonjs2',
   },
 
   plugins: [


### PR DESCRIPTION
Without a `libraryTarget` the webpack bundle is simply a self executing
function and so when imported, the function gets run, but never returns
any code for the parent module to use, making the module useless.

The difference between the targets `commonjs` and `commonjs2` are small, but the `commonjs` webpack compiler strips away `__esModule` which breaks ES6 imports of modules created with cf-package.
